### PR TITLE
improve openLinkInBrowser to support windows/linux/darwin

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,10 +40,15 @@ func openLinkInBrowser(link string) {
 		cmd := exec.Command("open", link)
 		cmd.Run()
 	case "linux":
+		out, err := exec.Command("which xdg-open").Output()
+		_ = out
+		if err != nil {
+			color.Red(fmt.Sprintf("Unable to open link, please install xdg-open."))
+		}
 		cmd := exec.Command("xdg-open", link)
 		cmd.Run()
 	default:
-		fmt.Printf("Unable to open link for OS %s.\n", os)
+		color.Red(fmt.Sprintf("Unable to open link for unsupported OS '%s'.\n", os))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -40,8 +40,7 @@ func openLinkInBrowser(link string) {
 		cmd := exec.Command("open", link)
 		cmd.Run()
 	case "linux":
-		out, err := exec.Command("which xdg-open").Output()
-		_ = out
+		_, err := exec.Command("which xdg-open").Output()
 		if err != nil {
 			color.Red(fmt.Sprintf("Unable to open link, please install xdg-open."))
 		}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/Songmu/prompter"
@@ -29,9 +30,21 @@ type knownIssuesWorkflowInputSchema struct {
 }
 
 func openLinkInBrowser(link string) {
-	color.Green(fmt.Sprintf("Your new ticket has been successfully created! The link is %s \nWe will now try to open the new ticket for you in the browser. (Probably doesn't work on Windows.)", link))
-	cmd := exec.Command("open", link)
-	cmd.Run()
+	color.Green(fmt.Sprintf("Your new ticket has been successfully created! The link is %s \nWe will now try to open the new ticket for you in the browser.", link))
+	os := runtime.GOOS
+	switch os {
+	case "windows":
+		cmd := exec.Command("start", link)
+		cmd.Run()
+	case "darwin":
+		cmd := exec.Command("open", link)
+		cmd.Run()
+	case "linux":
+		cmd := exec.Command("xdg-open", link)
+		cmd.Run()
+	default:
+		fmt.Printf("Unable to open link for OS %s.\n", os)
+	}
 }
 
 type cliArgs struct {


### PR DESCRIPTION
This PR improves the `openLinkInBrowser` function to support windows/linux/darwin operating systems.

This PR has been tested in a darwin environment only but the commands are correct for windows & linux.